### PR TITLE
Stripping out leading/trailing brackets

### DIFF
--- a/cu-monitor.lic
+++ b/cu-monitor.lic
@@ -38,7 +38,7 @@ loop do
         if DRRoom.description == "It's pitch dark and you can't see a thing!"
             room = "[Dark Room]"
         else
-            room = "#{DRRoom.title} [#{Room.current.id}]"
+            room = "#{DRRoom.title.tr('[]', '')} [#{Room.current.id}]"
         end
         
         DRC.message("#{material} #{room} --Session:#{contribid}")


### PR DESCRIPTION
Changes from

```
[exec1: [[Willow Walk, Willow Tree]]]                                                                                                                                                                                                         
```
to
```
[exec1: Willow Walk, Willow Tree]                                                                                                                                                                                                             
```